### PR TITLE
use hash_equals()

### DIFF
--- a/src/Middlewares/VerifySignature.php
+++ b/src/Middlewares/VerifySignature.php
@@ -32,6 +32,6 @@ class VerifySignature
 
         $computedSignature = hash_hmac('sha256', $payload, $secret);
 
-        return $signature === $computedSignature;
+        return hash_equals($signature, $computedSignature);
     }
 }


### PR DESCRIPTION
Its generally advised to use `hash_equals()` instead of doing a string comparison.

http://php.net/manual/en/function.hash-equals.php

I've built a few of these signature verification middlewares for http://laravel-shield.com lately and using `hash_equals()` was the advice I have seen.