### PR TITLE
Update Composer Dependencies for Laravel 11 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3.4",
-        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0"
+        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": "^8.0|^7.3",
-        "illuminate/http": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/routing": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0"
+        "php": "^8.3",
+        "illuminate/http": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/routing": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0"
 
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
+        "phpunit/phpunit": "^11.3.4",
         "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0"
     },
     "autoload": {


### PR DESCRIPTION
- **Updated Dependencies:**
  - Updated `php` version requirement to `^8.3`.
  - Updated `illuminate/http` to `^11.0`.
  - Updated `illuminate/routing` to `^11.0`.
  - Updated `illuminate/support` to `^11.0`
  
  